### PR TITLE
Silence BroadcastSession SessionInfo spam

### DIFF
--- a/LogCleaner/LogCleaner.cs
+++ b/LogCleaner/LogCleaner.cs
@@ -43,11 +43,15 @@ namespace LogCleaner
             AccessTools.Method(typeof(ContactData), "ClearExpired"),
             AccessTools.Method(typeof(UserStatusManager), "SendStatusToUser"),
             FindAsyncBody(AccessTools.Method(typeof(AppHub), "BroadcastStatus")),
+
+            // NEW: also silence BroadcastSession SessionInfo spam
+            FindAsyncBody(AccessTools.Method(typeof(AppHub), "BroadcastSession")),
         };
 
         public static MethodInfo FindAsyncBody (MethodInfo mi)
         {
-            AsyncStateMachineAttribute asyncAttribute = (AsyncStateMachineAttribute)mi.GetCustomAttribute(typeof(AsyncStateMachineAttribute));
+            AsyncStateMachineAttribute asyncAttribute =
+            (AsyncStateMachineAttribute)mi.GetCustomAttribute(typeof(AsyncStateMachineAttribute));
             Type asyncStateMachineType = asyncAttribute.StateMachineType;
             return AccessTools.Method(asyncStateMachineType, nameof(IAsyncStateMachine.MoveNext));
         }

--- a/LogCleaner/LogCleaner.cs
+++ b/LogCleaner/LogCleaner.cs
@@ -49,7 +49,7 @@ namespace LogCleaner
             FindAsyncBody(AccessTools.Method(typeof(AppHub), "BroadcastStatus")),
         };
 
-        public static MethodInfo FindAsyncBody (MethodInfo mi)
+        public static MethodInfo FindAsyncBody(MethodInfo mi)
         {
             AsyncStateMachineAttribute asyncAttribute = (AsyncStateMachineAttribute)mi.GetCustomAttribute(typeof(AsyncStateMachineAttribute));
             Type asyncStateMachineType = asyncAttribute.StateMachineType;


### PR DESCRIPTION
### 1.1.2 Update
- Suppresses spammy log lines:
  - `Running refresh on: ...` → dropped completely
  - `The OrderOffset ...` → still logs, but without stack traces
  - SIGNALR `BroadcastSession` spam → dropped completely
- Added `SyncElement.BeginModification(bool)` to stacktrace filter